### PR TITLE
Adding links to ressources provided by the Publications Office

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ Links should be directly to websites where data can be downloaded from, not to p
 - [The EU Free Movement of Goods Dataset](https://doi.org/10.7910/DVN/XJJ5N4) 
 - [GEOCOURT: Subnational Disparities in EU Law Use](https://euthority.eu/?page_id=795)
 
+#### Publications Office
+- [EU reference vocabularies and authority tables](https://op.europa.eu/en/web/eu-vocabularies/)
+- [data.europa.eu - The official portal for European data](https://data.europa.eu/en)
+
 #### Political communication
 - [European Commission press releases 1985-2020](https://doi.org/10.7910/DVN/UGGXUF)
 - [European Commissioner speeches 1985-2020](https://doi.org/10.7910/DVN/M2QFGM)
@@ -76,3 +80,4 @@ Links should be directly to websites where data can be downloaded from, not to p
 - [EUSSUE: Measuring issue attention in the European Union from daily news coverage](https://doi.org/10.7910/DVN/CXZAGB)
 - [European Union Sectoral Emissions Data (EUSED)](https://doi.org/10.7910/DVN/DW7Y5W)
 - [The European Union Member State (EUMS) Database](https://github.com/jfjelstul/eums)
+


### PR DESCRIPTION
Hi,

The EU vocabularies, from the Publications Office, are a crucial component to any effort related to European data : many institutions use the authority tables from the Office, and a lot of datasets are indexed with Eurovoc. If the link is unsatisfactory, I can suggest some specific resources to link to.

As for data.europa.eu, it's the official open data portal from the EU : is it OK to mention it or should specific resources be linked ? (by definition there are probably a lot of them)